### PR TITLE
Fixes for multiple routes and default API gateway schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,19 +25,22 @@ module.exports = exports = internals.Router = function(options) {
 };
 
 
-internals.Router.prototype.register = function(route) {
-  var routes = this.routes;
+internals.Router.prototype.register = function(more_routes) {
+  for (var i=0; i < more_routes.length; i++) {
+    var route = route[i];
+    var routes = this.routes;
 
-  Hoek.assert(route, 'route is required');
-  var result = Joi.validate(route, routerSchema);
-  if (result.error) {
-    throw (result.error);
-  }
+    Hoek.assert(route, 'route is required');
+    var result = Joi.validate(route, routerSchema);
+    if (result.error) {
+      throw (result.error);
+    }
 
-  if (!routes[route.path]) {
-    routes[route.path] = {};
+    if (!routes[route.path]) {
+      routes[route.path] = {};
+    }
+    routes[route.path][route.method.toUpperCase()] = route;
   }
-  routes[route.path][route.method.toUpperCase()] = route;
 };
 
 internals.Router.prototype.route = function(event, context) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = exports = internals.Router = function(options) {
 
 internals.Router.prototype.register = function(more_routes) {
   for (var i=0; i < more_routes.length; i++) {
-    var route = route[i];
+    var route = more_routes[i];
     var routes = this.routes;
 
     Hoek.assert(route, 'route is required');

--- a/index.js
+++ b/index.js
@@ -14,10 +14,8 @@ var routerSchema = Joi.object().keys({
 });
 
 var eventSchema = Joi.object().keys({
-  context: Joi.object().keys({
-    'resource-path': Joi.string().required(),
-    'http-method': Joi.string().required(),
-  }).unknown().required()
+    resource: Joi.string().required(),
+    httpMethod: Joi.string().required(),
 }).unknown().required();
 
 module.exports = exports = internals.Router = function(options) {
@@ -55,7 +53,7 @@ internals.Router.prototype.route = function(event, context) {
       return reject(error);
     }
 
-    if (event.context && event.context['resource-path']) {
+    if (event && event.resource) {
       let route = this._getRoute(event, context);
       if (route) {
         return route.handler(event, context)
@@ -99,9 +97,9 @@ internals.Router.prototype._validationError = function(error) {
 }
 
 internals.Router.prototype._getRoute = function(event, context) {
-  var entry = this.routes[event.context['resource-path']];
+  var entry = this.routes[event.resource];
   if (entry) {
-    return entry[event.context['http-method'].toUpperCase()];
+    return entry[event.httpMethod.toUpperCase()];
   } else {
     return null;
   }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var internals = {};
 var routerSchema = Joi.object().keys({
   path: Joi.string().required(),
   method: Joi.string().required(),
-  handler: Joi.func().arity(2).required()
+  handler: Joi.func().required()
 });
 
 var eventSchema = Joi.object().keys({


### PR DESCRIPTION
1. The default API gateway schema has "resource" and "httpMethod" keys directly within event when the Lambda Proxy option is used. So I have changed the event schema to use that. Please consider removing the template also as that will no longer be needed in this case.

2. The example code given for registering multiple routes does not work, because the register function assumed a single route. Changed it to handle array.

3. The router schema assumes that the arity of handler function must be 2. The example code only passes the event. So removed the arity requirement from the schema. Could also work with arity 1.